### PR TITLE
Upgrade venctl to v1.19.0

### DIFF
--- a/Formula/venctl.rb
+++ b/Formula/venctl.rb
@@ -2,26 +2,26 @@ class Venctl < Formula
   desc "Venafi CLI serves as an alternative to the Venafi Control Plane web interface"
   homepage "https://docs.venafi.cloud/vaas/venctl/c-venctl-overview"
   url "https://docs.venafi.cloud/vaas/venctl/c-venctl-releases"
-  version "1.18.0"
+  version "1.19.0"
   on_macos do
     if Hardware::CPU.intel?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-amd64.zip"
-      sha256 "bddecb6db5324a2462688a4f8051cec19f065a0b3f433e9eb81b4a2268bec5b0"
+      sha256 "2b232734f6cb377cbe1bcf2e637c36de32d5db0119350e9190fbebfcb89aafff"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-arm64.zip"
-      sha256 "412e0fcb8438c3711a064e4335e68fb73b440db83f0a6e2208fe7c4c35eea492"
+      sha256 "00132fd085073d8d9a0294e44db0e1cb9edaadb29acde75cca9c8b1f0121b4cb"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-amd64.zip"
-      sha256 "858ac25a9a0e8b63ec59d0eb1cc259177e66d880686939115a902c61aa664653"
+      sha256 "f06795cde250da2a366358cc4fab333781a1e969bdbb5a71fd252f08109854cb"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-arm64.zip"
-      sha256 "a25551f4a61e02e253cfbce030935d1880b04b736c32ca8a7626a63e0c999433"
+      sha256 "bac6b37b5068a5215624bdfe6d2897cb7011a9fb0172fe724654ae536a991fc5"
     end
   end
 


### PR DESCRIPTION
From the following SHASUMs:

```
2b232734f6cb377cbe1bcf2e637c36de32d5db0119350e9190fbebfcb89aafff  venctl-darwin-amd64.zip
00132fd085073d8d9a0294e44db0e1cb9edaadb29acde75cca9c8b1f0121b4cb  venctl-darwin-arm64.zip
f06795cde250da2a366358cc4fab333781a1e969bdbb5a71fd252f08109854cb  venctl-linux-amd64.zip
bac6b37b5068a5215624bdfe6d2897cb7011a9fb0172fe724654ae536a991fc5  venctl-linux-arm64.zip
20c01e10f809930f332360306092e222ab7a89e17725a93f77cb553b7a7c9c92  venctl-windows-amd64.zip
```