### PR TITLE
Update venctl to 1.27.0

### DIFF
--- a/Formula/venctl.rb
+++ b/Formula/venctl.rb
@@ -2,26 +2,26 @@ class Venctl < Formula
   desc "Venafi CLI serves as an alternative to the Venafi Control Plane web interface"
   homepage "https://docs.venafi.cloud/vaas/venctl/c-venctl-overview"
   url "https://docs.venafi.cloud/vaas/venctl/c-venctl-releases"
-  version "1.25.0"
+  version "1.27.0"
   on_macos do
     if Hardware::CPU.intel?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-amd64.zip"
-      sha256 "5401eaada078c5f69ed6180ef9e1082ad1db70e6b831578dc02f18e4979fd35c"
+      sha256 "4f75900c7b3256cc786004bd5d6193f95f505521e761a9917b3c3d243440f77e"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-darwin-arm64.zip"
-      sha256 "f47a00e88e9dd1c219794055550ce55dc3ddd73ce1fe22cbc4bbae033e0dc68e"
+      sha256 "1648b17020291f90b8c1195be8b963d96f7be31a6e43ba944dd104729f16d1c5"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-amd64.zip"
-      sha256 "85231d49c31ec0195d9b12af0b7396534707d6763fc9f6516386571f164555cd"
+      sha256 "f1027056ec243c7ea9183fe410d5daf99cd4fa18cff9149d64749a106832595a"
     end
     if Hardware::CPU.arm?
       url "https://dl.venafi.cloud/venctl/#{version}/venctl-linux-arm64.zip"
-      sha256 "89d32777e7aa38f6042a02a3a2423feb661d3942b2bf4d16c9fdd85249ce05d9"
+      sha256 "cf1fd57c8e72fd9dfeddd854f52768ab023131d062b58b28720ab0fa4954f2a5"
     end
   end
 


### PR DESCRIPTION
Update venctl formula to 1.27.0 with new SHA256 hashes.

```
$ curl -L https://dl.venafi.cloud/venctl/1.27.0/venctl-SHA256SUMS                                                        
4f75900c7b3256cc786004bd5d6193f95f505521e761a9917b3c3d243440f77e  venctl-darwin-amd64.zip
1648b17020291f90b8c1195be8b963d96f7be31a6e43ba944dd104729f16d1c5  venctl-darwin-arm64.zip
f1027056ec243c7ea9183fe410d5daf99cd4fa18cff9149d64749a106832595a  venctl-linux-amd64.zip
cf1fd57c8e72fd9dfeddd854f52768ab023131d062b58b28720ab0fa4954f2a5  venctl-linux-arm64.zip
5ecf8cea077e1ed6ab29df075d3b31db7f79d0de03dece492929ba361a125e9c  venctl-windows-amd64.zip
```