### PR TITLE
fix(deps): Project-Logos Pattern B (mixed) — VC-53641

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
       time: "09:00"
       day: "monday"
       timezone: "America/Inuvik"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "09:00"
+      day: "monday"
+      timezone: "America/Inuvik"


### PR DESCRIPTION
## Summary

This PR addresses supply chain security findings from Project Logos ticket VC-53641. The Dependabot configuration was missing monitoring for the github-actions ecosystem, which could leave GitHub Actions dependencies unmonitored for security updates.

## Findings addressed

- **Medium SC-004 CWE-1104**: Dependabot misconfigured: github-actions ecosystem not monitored
  - Added github-actions ecosystem to `.github/dependabot.yml` with weekly schedule matching the existing bundler configuration

## Local verification

- Configuration file updated with new github-actions ecosystem entry
- File uses consistent scheduling (weekly, Monday 09:00 America/Inuvik timezone)
- No build or tests required for configuration-only change

**Generated by Project Logos Pattern-B automated fix**