### PR TITLE
security: CWE-1357: Pin GitHub Actions to SHA digests — VC-53723

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
       time: "09:00"
       day: "monday"
       timezone: "America/Inuvik"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@521d40582eb7b2dc6c83001c590c455100248f27 # master
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # main
         with:
           name: bottles
           path: '*.bottle.*'


### PR DESCRIPTION
## Summary

This PR addresses CWE-1357 (Reliance on Insufficiently Trustworthy Component) by pinning all GitHub Actions workflow references to immutable SHA digests instead of mutable tags or branches.

## Finding

**Vulnerability**: CWE-1357 / CWE-494 - Unpinned GitHub Actions  
**CVSS Score**: 7.5 (High)  
**Ticket**: VC-53723

The Homebrew tap's GitHub Actions workflows referenced upstream actions using mutable version tags and branch names rather than digest-pinned SHA references:
- `Homebrew/actions/setup-homebrew@master` - mutable branch
- `actions/cache@v4` - mutable tag  
- `actions/upload-artifact@main` - mutable branch

This creates a supply chain security risk: if any upstream action is compromised through tag mutation or repository takeover, the Homebrew package build pipeline would execute attacker-controlled code with access to package signing keys, release credentials, and other CI secrets.

## Remediation

**Changes Applied**:

1. **Pinned all actions by SHA digest** in `.github/workflows/tests.yml`:
   - `Homebrew/actions/setup-homebrew@521d40582eb7b2dc6c83001c590c455100248f27` (was: `@master`)
   - `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830` (was: `@v4`)
   - `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (was: `@main`)

2. **Added Dependabot configuration** in `.github/dependabot.yml`:
   - Configured `github-actions` ecosystem monitoring
   - Weekly schedule for automated PR creation when action SHAs are updated
   - Ensures pinned actions stay current without manual tracking

**Files Modified**:
- `.github/workflows/tests.yml` - 3 action references pinned to SHA
- `.github/dependabot.yml` - Added github-actions update configuration

## Verification

- All workflow action references now use immutable SHA digests
- Dependabot will automatically track updates and create PRs when new action versions are available
- No functional changes to workflow behavior - purely security hardening

---
*Auto-remediation by Project Logos Pattern-C*