### PR TITLE
security: CWE-1357: add least-privilege workflow permissions — VC-53723

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   test-bot:
     strategy:


### PR DESCRIPTION
## Summary
Add explicit `permissions: contents: read` to the brew test-bot workflow to enforce least-privilege CI permissions, completing the CWE-1357 remediation.

## Finding
CWE-1357 / CWE-494: GitHub Actions workflows lacked explicit permission scoping. While action references were already digest-pinned (addressing the primary unpinned-actions concern), the workflow did not declare least-privilege `permissions`, leaving the default token with broader access than necessary.

## Remediation
- Added top-level `permissions: contents: read` to `.github/workflows/tests.yml`, restricting the `GITHUB_TOKEN` to read-only content access.
- Action references were already SHA-pinned and Dependabot was already configured for github-actions updates.

## Verification
- YAML syntax validated.
- No build/test regression (Homebrew tap — no compiled artifacts to test locally).