### PR TITLE
security: CWE-1104: Fix Dependabot config YAML indentation — VC-53641

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: 'bundler'
-      directory: "/Formula"
+    directory: "/Formula"
     schedule:
       interval: "weekly"
       time: "09:00"


### PR DESCRIPTION
## Summary

Fix broken YAML indentation in `.github/dependabot.yml` that prevented Dependabot from parsing the configuration file, effectively disabling monitoring for all ecosystems including `github-actions`.

## Finding

- **Ticket**: VC-53641
- **CWE**: CWE-1104 (Use of Unmaintained Third Party Components)
- **ID**: SC-004
- **Severity**: Medium
- **Issue**: The `directory` key under the `bundler` ecosystem entry was indented 6 spaces instead of 4, causing a YAML parse error. This rendered the entire Dependabot config invalid, so the `github-actions` ecosystem (already declared on lines 10-16) was never actually monitored.

## Remediation

Corrected the indentation of `directory: "/Formula"` from 6 spaces to 4 spaces, aligning it as a proper sibling key to `package-ecosystem`. This makes the YAML valid so Dependabot can process both the `bundler` and `github-actions` ecosystem entries.

## Verification

- YAML structure validated — both ecosystem entries are now correctly formatted.
- No build/test applicable (config-only change).
- Diff: 1 file changed, 1 insertion, 1 deletion.