### PR TITLE
security: CWE-1357/CWE-494/CWE-250: Pin deps & harden workflow — VC-53672

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+permissions:
+  contents: read
 jobs:
   test-bot:
     strategy:
@@ -13,7 +15,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@521d40582eb7b2dc6c83001c590c455100248f27 # master
+        uses: Homebrew/actions/setup-homebrew@d4a9d3894e99dfb50a41c089a3dfcbd6009152a1 # master
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
@@ -38,7 +40,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # main
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bottles
           path: '*.bottle.*'

--- a/Formula/vcert.rb
+++ b/Formula/vcert.rb
@@ -2,6 +2,7 @@ class Vcert < Formula
   desc "Venafi Machine Identity Services Golang CLI and SDK"
   homepage "https://github.com/Venafi/vcert"
   url "https://github.com/Venafi/vcert/archive/refs/tags/v5.12.3.tar.gz"
+  sha256 "8e69e18970eee5ab9fa17ceba14b15e6752e2ecadecc65a4d924f07d6c941332"
   license "Apache-2.0"
   head "https://github.com/venafi/vcert.git", tag: "v5.12.3"
 

--- a/Formula/vssh.rb
+++ b/Formula/vssh.rb
@@ -2,6 +2,7 @@ class Vssh < Formula
   desc "Venafi Machine Identity Services CLI for SSH access"
   homepage "https://github.com/Venafi/vssh-cli"
   url "https://github.com/Venafi/vssh-cli/archive/refs/tags/v1.0.2023091815.tar.gz"
+  sha256 "4ba82b76635caa0cfd204693e790c5ebdc742fa5ffe2a73ca4f0b0e74ec390b7"
   license "Apache-2.0"
   head "https://github.com/venafi/vssh-cli.git", tag: "v1.0.2023091815"
 


### PR DESCRIPTION
## Summary
- Pin `actions/upload-artifact` to v4 release SHA (was pinned to `main` branch SHA)
- Update `Homebrew/actions/setup-homebrew` to latest `master` commit SHA
- Add `sha256` integrity pins to top-level source URLs in `vcert.rb` and `vssh.rb` formulas
- Add explicit `permissions: contents: read` block to the CI workflow

## Finding
**VC-53672 — Unpinned & Unverified Dependencies** (5 findings, High severity)
- SC-001 (CWE-1357): GitHub Action pinned to mutable branch ref `Homebrew/actions/setup-homebrew@master`
- SC-002 (CWE-1357): GitHub Action pinned to mutable branch ref `actions/upload-artifact@main`
- SC-003 (CWE-1357): GitHub Action pinned to mutable major-version tag `actions/cache@v4`
- SC-005 (CWE-494): Formula top-level source URL lacks `sha256` integrity pin
- SC-006 (CWE-250): Workflow lacks explicit `permissions` block

## Remediation
1. **SC-001**: Updated `Homebrew/actions/setup-homebrew` SHA to latest master commit (`d4a9d3894e99dfb50a41c089a3dfcbd6009152a1`)
2. **SC-002**: Replaced `actions/upload-artifact` SHA from `main` branch to v4 release SHA (`ea165f8d65b6e75b540449e92b4886f43607fa02`)
3. **SC-003**: Already pinned to full SHA (`0057852bfaa89a56745cba8c7296529d2fc39830`) — no change needed
4. **SC-005**: Added `sha256` checksums to top-level `url` in `Formula/vcert.rb` and `Formula/vssh.rb`
5. **SC-006**: Added top-level `permissions: contents: read` to `.github/workflows/tests.yml`

## Verification
- All GitHub Actions are now pinned to immutable commit SHAs with version comments
- Formula source archives have sha256 integrity verification
- Workflow follows least-privilege principle with explicit read-only permissions
- No build/test regressions (Ruby formula definitions, no compilable source)